### PR TITLE
Print button now actually does something

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -7,7 +7,26 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+.showprint {
+  display: none;
+}
+
+@media print {
+  #root, .modal-content > :not(.modal-body) {
+    display: none !important;
+  }
+  .modal-content > .modal-body {
+    display: block !important;
+  }
+  .modal-content {
+    border: 0 !important;
+  }
+}
+
 code {
+  @media print {
+    display: none;
+  }
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }

--- a/client/src/routes/CheckOutPage/CheckOutPage.js
+++ b/client/src/routes/CheckOutPage/CheckOutPage.js
@@ -95,6 +95,7 @@ function CheckOutPage() {
                         <Button variant="primary" onClick={() => setErrMsg("")}>Close</Button>
                     </Modal.Footer>
                 </Modal>
+
                 <Modal 
                     show={show} 
                     onHide={handleClose}
@@ -105,14 +106,15 @@ function CheckOutPage() {
                         <Modal.Title>Check Out Confirmation</Modal.Title>
                     </Modal.Header>
                     <Modal.Body>Successfully checked out items
+                        {/* print checkout info */}
                         <CheckOutTable assets={currentAssetList}></CheckOutTable>
                     </Modal.Body>
                     <Modal.Footer>
                         <Button variant="secondary" onClick={handleClose}>Close</Button>
-                        <Button variant="primary" onClick={handleClose}>Print Check Out Record</Button>
-                        {/* Should export/print the information on the confirmation modal when clicked */}
+                        <Button variant="primary" onClick={window.print}>Print Check Out Record</Button>
                     </Modal.Footer>
                 </Modal>
+
 
             </div>
 


### PR DESCRIPTION
Printing the checkout confirmation page opens a print window containing the modal body.
This is achieved with CSS code and `window.print`.